### PR TITLE
feat(yazi): add flavor system and clean up theme config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 !tmux-powerline/**
 !tmux/**
 !yazi/**
+yazi/flavors/
 
 # git submodules directories
 !iterm/**

--- a/yazi/package.toml
+++ b/yazi/package.toml
@@ -28,5 +28,12 @@ use = "yazi-rs/plugins:piper"
 rev = "9a52857"
 hash = "a20327710c3a8d37ee0972128dcb6a31"
 
-[flavor]
-deps = []
+[[flavor.deps]]
+use = "yazi-rs/flavors:catppuccin-mocha"
+rev = "0f9204b"
+hash = "9f49a591c5a86578da7000b1816329c1"
+
+[[flavor.deps]]
+use = "BennyOe/tokyo-night"
+rev = "8e6296f"
+hash = "f9adc0d1e58cbcfc5f39046383a25d9f"

--- a/yazi/theme.toml
+++ b/yazi/theme.toml
@@ -5,8 +5,8 @@
 # vim:fileencoding=utf-8:foldmethod=marker
 
 [flavor]
-dark  = "tokyo-night"
-light = "tokyo-night"
+dark  = "catppuccin-mocha"
+light = "catppuccin-mocha"
 
 
 [mgr]

--- a/yazi/theme.toml
+++ b/yazi/theme.toml
@@ -5,23 +5,42 @@
 # vim:fileencoding=utf-8:foldmethod=marker
 
 [flavor]
+# Available flavors (install with `ya pkg add <source>`):
+#   catppuccin-mocha    — yazi-rs/flavors:catppuccin-mocha       暖灰底 + 柔和 pastel
+#   catppuccin-macchiato— yazi-rs/flavors:catppuccin-macchiato   深暖灰底 + 浓郁 pastel
+#   catppuccin-frappe   — yazi-rs/flavors:catppuccin-frappe      中暖灰底 + 柔和 pastel
+#   catppuccin-latte    — yazi-rs/flavors:catppuccin-latte       浅色底 + 柔和 pastel
+#   tokyo-night         — BennyOe/tokyo-night                    深蓝黑底 + 冷色蓝系
+#   kanagawa            — dangooddd/kanagawa                      深蓝紫底 + 金色/青色
+#   kanagawa-dragon     — marcosvnmelo/kanagawa-dragon            深色暖调 + 红/金
+#   kanagawa-lotus      — muratoffalex/kanagawa-lotus             浅色日式
+#   kanagawa-paper      — melindachang/kanagawa-paper             纸白底 + 墨色
+#   gruvbox-dark        — bennyyip/gruvbox-dark                   深暖色 + 橙/黄/绿
+#   gruvbox-material    — matt-dong-123/gruvbox-material          深暖色 + 材质感
+#   dracula             — yazi-rs/flavors:dracula                 深紫底 + 绿/紫/橙
+#   rose-pine           — Mintass/rose-pine                       深色底 + 玫瑰/松木色
+#   rose-pine-moon      — Mintass/rose-pine                       月光暗色版
+#   rose-pine-dawn      — Mintass/rose-pine                       浅色版
+#   nord                — AdithyanA2005/nord                      极深蓝底 + 冰蓝/霜白
+#   everforest-medium   — Chromium-3-Oxide/everforest-medium      深绿灰底 + 自然色系
+#   ayu-dark            — kmlupreti/ayu-dark                      深灰底 + 橙色高亮
+#   ashen               — ashen-org/ashen                         灰调暗色
+#   flexoki-dark        — gosxrgxx/flexoki-dark                   暖白纸底 + 墨色系
+#   flexoki-light       — gosxrgxx/flexoki-light                  浅色版 flexoki
+#   neon                — tomer-ben-david/neon                    霓虹荧光色
+#   synthwave84         — CFY98/synthwave84                       合成波复古风
+#   bluloco-dark        — hankertrix/bluloco-yazi                 深色蓝调
+#   bluloco-light       — hankertrix/bluloco-yazi                 浅色蓝调
+#   monokai             — Malick-Tammal/monokai                   经典 Monokai
+#   eldritch            — 6ruby1/eldritch                         暗色 + 绿/紫
+#   base16              — 使用终端配色，适配任何主题
+#   claude-inspired     — rapidrabbit76/claude-inspired           Claude 配色风格
+#   lain                — identityapproved/lain                   赛博朋克风
+#   obsidian-glow       — ZimCodes/yazi-flavors                   深色 + 柔光
+#   modus               — 社区                                   Emacs modus 风格
 dark  = "catppuccin-mocha"
 light = "catppuccin-mocha"
 
 
 [mgr]
-
-# Tab
-tab_width = 12
-
-# Border
 border_symbol = " "
-border_style  = { fg = "gray" }
-
-# Highlighting
-syntect_theme = ""
-
-[status]
-mode_normal = { bg = "blue", bold = true }
-mode_select = { bg = "red", bold = true }
-mode_unset  = { bg = "yellow", bold = true }

--- a/yazi/theme.toml
+++ b/yazi/theme.toml
@@ -5,7 +5,8 @@
 # vim:fileencoding=utf-8:foldmethod=marker
 
 [flavor]
-use = ""
+dark  = "tokyo-night"
+light = "tokyo-night"
 
 
 [mgr]


### PR DESCRIPTION
## Changes

- Add catppuccin-mocha flavor as active theme (`dark`/`light` fields)
- Add commented flavor index listing all 32 community flavors with install commands
- Clean up theme.toml: remove invalid/deprecated fields (`tab_width`, `border_style`, `syntect_theme`, `mode_normal/select/unset` under `[status]`)
- Keep only minimal overrides: invisible border (`border_symbol = " "`)
- Add `yazi/flavors/` to `.gitignore` (managed by `ya pkg`)

## Note

Since history was rewritten with `git filter-repo` to remove flavor binaries, this branch cannot be fast-forwarded. Use rebase or squash merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)