### PR TITLE
feat(submodule): add ai submodule for AI-related configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ yazi/flavors/
 !nvim/**
 !zsh/**
 !deploy/**
+!ai/
+!ai/**
 
 # do not ignore picom.conf
 !picom.conf

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "ssh"]
 	path = ssh
 	url = git@gist.github.com:61daec6d250eed65519f32f200196228.git
+[submodule "ai"]
+	path = ai
+	url = git@github.com:tr1v3r/ai-config.git


### PR DESCRIPTION
## Summary

- Added private repo `tr1v3r/ai-config` as submodule at `ai/`
- Updated `.gitignore` to whitelist `ai/` directory
- Initial content: skill & MCP inventory summary

## Changes

| File | Change |
|------|--------|
| `.gitignore` | Added `!ai/` and `!ai/**` rules |
| `.gitmodules` | Registered new submodule `ai` |
| `ai` | New submodule (points to `tr1v3r/ai-config`) |