### PR TITLE
Harden GnuPG configuration deployment

### DIFF
--- a/gpg/common.conf
+++ b/gpg/common.conf
@@ -1,0 +1,2 @@
+# Keep the existing public-key database backend.
+use-keyboxd

--- a/gpg/gpg-agent.macos.conf
+++ b/gpg/gpg-agent.macos.conf
@@ -1,49 +1,15 @@
-# Enable SSH support for using GPG keys for SSH authentication
+# Expose gpg-agent through the OpenSSH agent protocol.
 enable-ssh-support
 
-# Print verbose log
-# verbose
+# Keep passphrase caching bounded. These are GnuPG's standard defaults.
+default-cache-ttl 600
+default-cache-ttl-ssh 1800
+max-cache-ttl 7200
+max-cache-ttl-ssh 7200
 
-# Cache settings
+# Uncomment to prevent Pinentry from using an external password cache,
+# such as macOS Keychain.
+# no-allow-external-cache
 
-# Cache passphrase for 24 hours (86400 seconds, default 600 seconds)
-default-cache-ttl 86400
-
-# Cache passphrase for SSH keys for 10 days (864000 seconds, default 1800 seconds)
-default-cache-ttl-ssh 864000
-
-# Max cache duration: 24 hours (86400 seconds, default 7200 seconds)
-max-cache-ttl 86400
-
-# Max cache duration for SSH: 10 days (864000 seconds, default 7200 seconds)
-max-cache-ttl-ssh 864000
-
-# Enforce passphrase input every time
-# enforce-passphrase-constraints
-
-# Deprecated option
-# Use the pinentry mode that fits your setup. For GUI environments, 'popup' might work.
-# For terminal-only use, 'tty' is appropriate.
-# pinentry-mode loopback
-
-# If you're using a modern system with proper entropy, you might want to
-# use stronger digest algorithms than the default.
-# Below setting makes GPG use SHA256 for SSH fingerprints.
-ssh-fingerprint-digest sha256
-
-# Logging - useful for debugging
-# Be cautious with using 'debug' level in a production environment as it might
-# reveal more information than desired.
-# log-file /path/to/your/logfile.log
-# debug-level basic
-
-# Other potential options depending on your use:
-
-# Prevent gpg-agent from accessing any external password cache.
-#no-allow-external-cache
-
-# If you're using a smartcard or hardware token:
-#enable-scdaemon
-
-# set pinentry-program for macOS
+# Homebrew on Apple Silicon.
 pinentry-program /opt/homebrew/bin/pinentry-mac

--- a/gpg/gpg.conf
+++ b/gpg/gpg.conf
@@ -1,53 +1,39 @@
-# set default algo list
-default-preference-list SHA512 SHA384 SHA256 SHA224 AES256 AES192 AES CAST5 ZLIB BZIP2 ZIP Uncompressed
+# Outgoing algorithm preferences
+personal-cipher-preferences AES256 AES192 AES
+personal-digest-preferences SHA512 SHA384 SHA256
+personal-compress-preferences ZLIB ZIP Uncompressed
 
-# set SHA256 as default cert digest aloo
+# Preferences advertised by new keys and used by setpref
+default-preference-list AES256 AES192 AES OCB SHA512 SHA384 SHA256 ZLIB ZIP Uncompressed
+
+# Key certification signatures
 cert-digest-algo SHA256
 
-# set SHA256 as default digest aloo
-digest-algo SHA256
-
-# set s2k mode options
-s2k-mode 3
-s2k-count 65011712
+# Passphrase-based symmetric encryption
 s2k-digest-algo SHA512
 s2k-cipher-algo AES256
 
-# disable weak or unsafe algo
-disable-cipher-algo CAST5
-disable-cipher-algo DES
-disable-cipher-algo 3DES
-disable-pubkey-algo DSA
-disable-pubkey-algo ELG
-disable-cipher-algo MD5
-disable-cipher-algo RSA
+# Strict policy: reject SHA-1 signatures. Comment this out temporarily
+# when historical SHA-1 signatures must be verified.
 weak-digest SHA1
 
-# UI configurations
+# User interface
 no-greeting
-no-verbose
 keyid-format 0xlong
 list-options show-uid-validity
 verify-options show-uid-validity
 with-fingerprint
-
-# use UTF-8 charset
 charset utf-8
 
-# set key server
-# keyserver hkps://hkps.pool.sks-keyservers.net
-# keyserver-options no-honor-keyserver-url
-# keyserver-options auto-key-retrieve
-
-# if you set key server and want more private, u may uncomment following line
-# keyserver-options no-honor-keyserver-url
-
-# set trust-model, which is recommended by GPG 2.1+
-# tofu -- Trust On First Use
+# Explicit trust-policy choice
 trust-model tofu+pgp
 
-# if you dont want comment generated, uncomment following line
-# no-emit-version
+# GnuPG uses the last default-key for which a secret key is available.
+# personal
+default-key 899318F5A4423B72DF6A166FE4AF5FF89222F261
 
-default-key r1v3r
-encrypt-to r1v3r
+# work; preferred when both secret keys are available
+default-key C633910E8F351365DEAAF300046263C39890F916
+
+# Add the selected default key as an additional encryption recipient.
+encrypt-to-default-key

--- a/scripts/deploy_config.sh
+++ b/scripts/deploy_config.sh
@@ -1,39 +1,87 @@
 #!/bin/bash
 
-# 需要 root 权限执行此脚本
-if [[ $EUID -ne 0 ]]; then
-	echo "Please run this script as root"
-	exit 1
-fi
-
 abort() {
 	echo "abort: $1"
 	exit 1
 }
 
-deploy() {
+link_config() {
+	local source_path="$1"
+	local target_path="$2"
+	local backup_path
+
+	if [ ! -e "$source_path" ]; then
+		abort "link source does not exist: $source_path"
+	fi
+
+	if [ -L "$target_path" ] && [ "$(readlink "$target_path")" = "$source_path" ]; then
+		echo "already linked: $target_path"
+		return
+	fi
+
+	if [ -e "$target_path" ] || [ -L "$target_path" ]; then
+		backup_path="${target_path}.bak.$(date +%Y%m%d%H%M%S)"
+		mv "$target_path" "$backup_path" || abort "backup $target_path fail."
+		echo "backed up $target_path to $backup_path"
+	fi
+
+	ln -s "$source_path" "$target_path" || abort "link $target_path fail."
+}
+
+link_system_config() {
+	local source_path="$1"
+	local target_path="$2"
+	local backup_path
+
+	if [ ! -e "$source_path" ]; then
+		abort "link source does not exist: $source_path"
+	fi
+
+	if [ -L "$target_path" ] && [ "$(readlink "$target_path")" = "$source_path" ]; then
+		echo "already linked: $target_path"
+		return
+	fi
+
+	if [ -e "$target_path" ] || [ -L "$target_path" ]; then
+		backup_path="${target_path}.bak.$(date +%Y%m%d%H%M%S)"
+		sudo mv "$target_path" "$backup_path" || abort "backup $target_path fail."
+		echo "backed up $target_path to $backup_path"
+	fi
+
+	sudo ln -s "$source_path" "$target_path" || abort "link $target_path fail."
+}
+
+deploy_common() {
 	# clone .config repo
-	if [ ! -d ~/.config ]; then
-		echo "git clone git@github.com:tr1v3r/.config.git ~/.config"
-		git clone git@github.com:tr1v3r/.config.git ~/.config || abort "git clone .config fail."
+	if [ ! -d "$HOME/.config" ]; then
+		echo "git clone git@github.com:tr1v3r/.config.git $HOME/.config"
+		git clone git@github.com:tr1v3r/.config.git "$HOME/.config" || abort "git clone .config fail."
 	fi
 
 	# link symbol
 	echo "linking .zshrc.local"
-	rm -f ~/.zshrc.local && ln -s ~/.config/zsh/work.mac.zsh ~/.zshrc.local || abort "link to ~/.zshrc.local fail."
+	link_config "$HOME/.config/zsh/work.mac.zsh" "$HOME/.zshrc.local"
 	echo "linking lazygit"
-	rm -f ~/Library/Application\ Support/lazygit && ln -s ~/.config/lazygit ~/Library/Application\ Support/lazygit || abort "link to ~/.zshrc.local fail."
+	link_config "$HOME/.config/lazygit" "$HOME/Library/Application Support/lazygit"
 	echo "linking Firefox chrome dir"
 	FIREFOX_PROFILE="$HOME/Library/Application Support/Firefox/Profiles/wwg09b6h.default-release"
-	rm -rf "$FIREFOX_PROFILE/chrome" && ln -s "$HOME/.config/firefox" "$FIREFOX_PROFILE/chrome" || abort "link to Firefox chrome fail."
+	link_config "$HOME/.config/firefox" "$FIREFOX_PROFILE/chrome"
 	echo "linking cargo config"
-	rm -f ~/.cargo/config && ln -s ~/.config/cargo/config ~/.cargo/config || abort "link to ~/.cargo/config fail."
-	echo "linking gpg agent config"
-	rm -f ~/.gnupg/gpg-agent.conf && ln -s ~/.config/gpg/gpg-agent.conf ~/.gnupg/gpg-agent.conf || abort "link to ~/.gnupg/gpg-agent.conf fail."
+	link_config "$HOME/.config/cargo/config" "$HOME/.cargo/config"
+	echo "linking GnuPG shared config"
+	mkdir -p "$HOME/.gnupg" || abort "create $HOME/.gnupg fail."
+	chmod 700 "$HOME/.gnupg" || abort "chmod $HOME/.gnupg fail."
+	link_config "$HOME/.config/gpg/gpg.conf" "$HOME/.gnupg/gpg.conf"
+	link_config "$HOME/.config/gpg/common.conf" "$HOME/.gnupg/common.conf"
 	echo "linking condarc"
-	rm -f ~/.condarc && ln -s ~/.config/conda/condarc ~/.condarc || abort "link to ~/.condarc fail."
+	link_config "$HOME/.config/conda/condarc" "$HOME/.condarc"
+}
+
+deploy_macos() {
+	echo "linking macOS GPG agent config"
+	link_config "$HOME/.config/gpg/gpg-agent.macos.conf" "$HOME/.gnupg/gpg-agent.conf"
 	echo "linking /etc/iterm2"
-	rm -f /etc/iterm2 && ln -s ~/.config/iterm2 /etc/iterm2 || abort "link to /etc/iterm2 fail."
+	link_system_config "$HOME/.config/iterm2" "/etc/iterm2"
 }
 
 SYS_TYPE=$(uname -s)
@@ -41,11 +89,13 @@ SYS_TYPE=$(uname -s)
 case $SYS_TYPE in
 "Darwin")
 	echo "deploying config on Darwin"
-	deploy
+	deploy_common
+	deploy_macos
 	;;
 "Linux")
 	echo "deploying config on Linux"
-	deploy
+	deploy_common
+	echo "skipping macOS-specific GPG agent and iTerm2 configs"
 	;;
 *)
 	echo "Unknown SYS type: $SYS_TYPE"


### PR DESCRIPTION
## Summary

This change modernizes the shared GnuPG policy, makes personal/work key selection portable across machines, tightens macOS agent caching, and makes configuration deployment idempotent and non-destructive.

The PR targets `dev` because `feature/gpg` was branched from `dev`; targeting `master` would include unrelated development commits.

## Why each change was made

### `gpg/gpg.conf`

1. **Define explicit outgoing cipher preferences: `AES256 AES192 AES`.**
   - Limits newly created messages to the broadly supported AES family.
   - Removes CAST5 and other legacy choices from the sender preference list without globally disabling algorithms that may still be needed to read historical data.

2. **Define explicit outgoing digest preferences: `SHA512 SHA384 SHA256`.**
   - Keeps data signatures on modern SHA-2 digests.
   - Drops SHA-224 from the preferred set because it provides no interoperability or security advantage over SHA-256 for this setup.
   - SHA-1 is deliberately excluded from creation preferences.

3. **Define explicit compression preferences: `ZLIB ZIP Uncompressed`.**
   - Retains the common interoperable formats while removing BZIP2 from the preferred set.
   - Keeps `Uncompressed` as a fallback for already-compressed or compatibility-sensitive data.

4. **Modernize `default-preference-list`.**
   - Uses the same AES/SHA-2/compression policy for newly generated keys and later `setpref`/`--quick-update-pref` operations.
   - Advertises OCB as the preferred AEAD mode where peers support AEAD.
   - This setting does not retroactively rewrite existing key self-signatures; existing keys need an explicit preference update.

5. **Keep `cert-digest-algo SHA256`.**
   - Ensures key certifications and self-signatures use SHA-256, which is modern and highly interoperable.

6. **Remove the global `digest-algo SHA256` override.**
   - A global forced digest can unnecessarily override normal algorithm selection and recipient compatibility handling.
   - `personal-digest-preferences` and `cert-digest-algo` express the intended policy at the correct scopes.

7. **Remove the hard-coded S2K mode and iteration count, while retaining SHA-512/AES-256.**
   - A fixed iteration count ages poorly as machines get faster and can bypass improvements in GnuPG defaults.
   - `s2k-digest-algo SHA512` and `s2k-cipher-algo AES256` preserve the desired primitives for passphrase-based symmetric encryption.

8. **Replace broad and partly invalid algorithm-disable directives with `weak-digest SHA1`.**
   - The previous block mixed cipher, digest, and public-key namespaces (for example, MD5 and RSA were listed as ciphers).
   - Globally disabling old public-key/cipher algorithms can prevent access to historical material.
   - `weak-digest SHA1` precisely rejects SHA-1 signatures while leaving legacy decryption capability available.
   - Historical files still decrypt with the corresponding secret key; signed historical content using SHA-1 may require temporarily commenting out this strict verification policy.

9. **Retain an explicit `tofu+pgp` trust model and concise UI settings.**
   - Keeps the existing combined TOFU/Web-of-Trust behavior intentional and documented.
   - Removes redundant comments and options whose default behavior already matches the desired non-verbose UI.

10. **Use full fingerprints for multiple `default-key` entries.**
    - Adds the personal key `899318F5A4423B72DF6A166FE4AF5FF89222F261` and work key `C633910E8F351365DEAAF300046263C39890F916`.
    - Full fingerprints avoid ambiguous or mutable UID-based selection.
    - GnuPG uses the last configured default key whose secret key is available, so work is preferred on work machines while personal remains a fallback elsewhere.

11. **Replace fixed `encrypt-to r1v3r` with `encrypt-to-default-key`.**
    - Removes dependence on a machine-specific/renamed UID.
    - Adds whichever usable default key was selected as an additional recipient, preserving self-decryption of newly encrypted outgoing data across different computers.

### `gpg/gpg-agent.macos.conf`

1. **Keep OpenSSH agent support enabled.**
   - Preserves use of GPG authentication keys through the SSH agent protocol.

2. **Reduce passphrase cache lifetimes to bounded GnuPG defaults.**
   - General cache: 10-minute default, 2-hour maximum.
   - SSH cache: 30-minute default, 2-hour maximum.
   - Replaces the previous 24-hour general cache and 10-day SSH cache, reducing the time an unlocked credential remains reusable after unattended access.

3. **Document, but do not force, external-cache disabling.**
   - Leaves macOS Keychain integration available by default.
   - Keeps `no-allow-external-cache` as an explicit opt-in for machines that require stricter behavior.

4. **Remove obsolete, misplaced, or purely diagnostic commented options.**
   - Avoids suggesting `pinentry-mode loopback` as an agent-side setting.
   - Removes unused debug/logging and smartcard commentary that does not change behavior.
   - Removes the unnecessary SSH fingerprint digest override.

5. **Retain the Apple Silicon Homebrew Pinentry path.**
   - Ensures graphical passphrase prompts continue to use `/opt/homebrew/bin/pinentry-mac` on the intended macOS hosts.

### `gpg/common.conf`

1. **Track `common.conf` with `use-keyboxd`.**
   - Makes the existing public-key database backend explicit when all `~/.gnupg` configuration files are deployed as symlinks.
   - Avoids accidentally changing the key database backend merely because the configuration is now managed from this repository.

### `scripts/deploy_config.sh`

1. **Stop requiring the entire script to run as root.**
   - User configuration should be created with the user's ownership and permissions.
   - `sudo` is now limited to the `/etc/iterm2` system link that actually requires elevated access.

2. **Add an idempotent `link_config` helper.**
   - Validates that every source exists before touching its target.
   - Leaves an already-correct symlink unchanged.
   - Backs up existing files, directories, or incorrect symlinks with a timestamp before linking.
   - Replaces destructive `rm -f`/`rm -rf` deployment behavior, particularly for the Firefox profile directory and existing GnuPG configuration.

3. **Add a separate `link_system_config` helper.**
   - Applies the same validation, idempotency, and timestamped backup behavior to system-owned targets.
   - Uses `sudo` only for the operations that need it.

4. **Quote `$HOME` and paths containing spaces consistently.**
   - Prevents word-splitting bugs for paths such as `~/Library/Application Support`.
   - Makes source and target paths explicit and easier to audit.

5. **Create and secure `~/.gnupg` before linking.**
   - Ensures the directory exists with mode `0700`, as required for private GnuPG state.

6. **Deploy both shared GnuPG configuration files.**
   - Links repository-managed `gpg.conf` and `common.conf` into `~/.gnupg`.
   - This makes the cryptographic policy and database backend consistent across supported machines.

7. **Deploy the macOS agent configuration only on Darwin.**
   - Links `gpg-agent.macos.conf` to `~/.gnupg/gpg-agent.conf` on macOS.
   - Fixes the previous reference to a non-existent generic `gpg-agent.conf` source.
   - Linux deployment explicitly skips the macOS-specific Pinentry and iTerm2 settings.

8. **Preserve existing non-GPG targets during redeployment.**
   - zsh, lazygit, Firefox, Cargo, Conda, and iTerm2 targets now receive the same backup-before-link treatment.
   - Re-running the script is safe when links are already correct.

## User impact

- Work machines prefer the work key; machines without that secret key fall back to the personal key.
- New outgoing encrypted data includes the selected default key as a recovery recipient.
- Existing encrypted files are not modified and remain decryptable as long as their original secret encryption key/subkey is retained.
- SHA-1-signed historical material may fail strict signature verification until the `weak-digest SHA1` line is temporarily disabled.
- Passphrase prompts may occur more often because the previous unusually long agent cache windows were reduced.
- First deployment preserves pre-existing targets as timestamped backups instead of deleting them.

## Validation

- [x] `git diff --check origin/dev...HEAD`
- [x] `bash -n scripts/deploy_config.sh`
- [x] `shellcheck scripts/deploy_config.sh`
- [x] Confirmed the working tree is clean and the branch contains exactly one commit over `dev`
- [ ] Run the deployment script interactively on a target macOS host (not run automatically because it changes files under `~/.gnupg` and `/etc`)
- [ ] Reload `gpg-agent` after deployment and verify Pinentry/SSH behavior on the target host
